### PR TITLE
Add rawdata option to Advertisement.parse() for Shizuku and Kizuku.

### DIFF
--- a/lib/modules/advertising.js
+++ b/lib/modules/advertising.js
@@ -17,7 +17,7 @@ const LinkingAdvertising = function() {};
 * Method: parse(peripheral)
 * - buf: `Peripheral` object of the noble)
 * ---------------------------------------------------------------- */
-LinkingAdvertising.prototype.parse = function(peripheral) {
+LinkingAdvertising.prototype.parse = function(peripheral, rawdata) {
 	let ad = peripheral.advertisement;
 	let manu = ad.manufacturerData;
 	if(!manu || manu.length < 8) {
@@ -37,12 +37,21 @@ LinkingAdvertising.prototype.parse = function(peripheral) {
 	let indi_num = ((manu.readUInt32BE(3) >>> 8) & (Math.pow(2, 20) - 1));
 	// Beacon Data
 	let beacon_data_list = [];
-	for(let offset=6; offset<manu.length; offset+=2) {
-		let beacon_buf = manu.slice(offset, offset + 2);
-		// Beacon service data
-		if(beacon_buf.length === 2) {
-			let beacon_data = this._parseBeaconServiceData(beacon_buf);
-			beacon_data_list.push(beacon_data);
+	if (rawdata) {
+		// do not parse beacn data
+		beacon_data_list.push({
+			name: 'Raw data (Buffer)',
+			serviceId: 16,
+			rawdata: manu.slice(6)
+		});
+	} else {
+		for(let offset=6; offset<manu.length; offset+=2) {
+			let beacon_buf = manu.slice(offset, offset + 2);
+			// Beacon service data
+			if(beacon_buf.length === 2) {
+				let beacon_data = this._parseBeaconServiceData(beacon_buf);
+				beacon_data_list.push(beacon_data);
+			}
 		}
 	}
 


### PR DESCRIPTION
Add rawdata option not to parse encrypted beacon data.